### PR TITLE
Turn on 180 rotation for Azoteq touchpads when set to left hand.

### DIFF
--- a/keyboards/svalboard/azoteq/config.h
+++ b/keyboards/svalboard/azoteq/config.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifdef INIT_EE_HANDS_LEFT
+#define AZOTEQ_IQS5XX_ROTATION_180 true
+#endif
+
 #define I2C_DRIVER I2CD0
 #define I2C1_SDA_PIN GP16
 #define I2C1_SCL_PIN GP17


### PR DESCRIPTION
The unit has a physical slant to match the Svalboard Lightly right and left-hand units. This automatically enables 180-degree rotation for the left hand.

Tested on a left-hand unit.