### PR TITLE
Greatly Reduce Azoteq Hold Time for dragging/scrolling motions, added extra DPI & MouseKeys Auto timeout choices

### DIFF
--- a/keyboards/svalboard/azoteq/config.h
+++ b/keyboards/svalboard/azoteq/config.h
@@ -7,7 +7,8 @@
 #define AZOTEQ_IQS5XX_TPS43
 #define AZOTEQ_IQS5XX_TIMEOUT_MS 10
 #define AZOTEQ_IQS5XX_PRESS_AND_HOLD_ENABLE true
-
+//This decreases the required 'wait' time to activate dragging/selecting on a touchpad from default 300ms to 20ms. Big QoL. 
+#define AZOTEQ_IQS5XX_HOLD_TIME 20
 //#define POINTING_DEVICE_MOTION_PIN GP18
 
 #define SPLIT_POINTING_ENABLE

--- a/keyboards/svalboard/svalboard.c
+++ b/keyboards/svalboard/svalboard.c
@@ -4,7 +4,7 @@
 #include "split_common/transactions.h"
 
 saved_values_t global_saved_values;
-const int16_t mh_timer_choices[4] = { 300, 500, 800, -1 }; // -1 is infinite.
+const int16_t mh_timer_choices[6] = { 200, 300, 400, 500, 800, -1 }; // -1 is infinite.
 
 uint8_t sval_active_layer = 0;
 #ifdef VIAL_ENABLE
@@ -74,7 +74,7 @@ const char *yes_or_no(int flag) {
     }
 }
 
-const uint16_t dpi_choices[] = { 200, 400, 800, 1200, 1600, 2400 }; // If we need more, add them.
+const uint16_t dpi_choices[] = { 200, 400, 600, 800, 1200, 1600, 2400 }; // If we need more, add them.
 #define DPI_CHOICES_LENGTH (sizeof(dpi_choices)/sizeof(dpi_choices[0]))
 
 void output_keyboard_info(void) {

--- a/keyboards/svalboard/svalboard.h
+++ b/keyboards/svalboard/svalboard.h
@@ -18,7 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "quantum.h"
 
-extern const int16_t mh_timer_choices[4];
+extern const int16_t mh_timer_choices[6];
 extern bool fresh_install;
 
 struct layer_hsv {


### PR DESCRIPTION
Hello! Per our small discussion in the svalboard discord, I have created a new branch and implemented some super minor tweaks in my branch _azo-touches-9-2025_

1. I added `#define AZOTEQ_IQS5XX_HOLD_TIME 20` to `keyboards/svalboard/azoteq/config.h` to alter the default (and until this moment, undefined/undeclared, functionality of Hold-Tap action on the Azoteq touchpad. The default 300 ms hold time forces any azoteq user to wait 'a beat' whenever they wish to interact with a window resizing handle, or window moving frame. It also affects the ability to select text or drag and drop files. Lowering it to 20 ms greatly increases comfort. You can see this documented simply, here: https://docs.qmk.fm/features/pointing_device#gesture-settings

2. I increased the defined array, `extern const int16_t mh_timer_choices[6];` in `keyboards/svalboard/svalboard.h` from the previous 4 options. This will come into play in...

3. `keyboards/svalboard/svalboard.c` where I have matched the array number from 2. and used the extra array options to provide 200 ms, and 400 ms timeouts for mousekeys. `const int16_t mh_timer_choices[6] = { 200, 300, 400, 500, 800, -1 }; // -1 is infinite.`

4. Farther down in the same file, I had added 600 as a dpi choice in that options array: `const uint16_t dpi_choices[] = { 200, 400, 600, 800, 1200, 1600, 2400 }; // If we need more, add them.`

**_4-A._** There is a final tweak I made, that is not included in this PR, since the way I handled it was clunky, and we believe there is a cleaner way to handle letting the sval-sides communicate their status and appropriately handle a toggle for it, but to sum it it up: 

If you use a left-sided azoteq as a dedicated scrolling device (SCROLL_LOCKED), you may find that the single-finger 'scroll' and the two-finger scroll act inverted to each other.

If you navigate to `keyboards/svalboard/keymaps/keymap_support.c` and find the function `if ((global_saved_values.left_scroll != scroll_hold) != scroll_toggle) ...` simply adjust the converted output of `reportMouse1.v = add_to_axis(&l_y -reportMouse1.y);` to `reportMouse1.v = add_to_axis(&l_y, reportMouse1.y);` 

Next steps, to better implement the axis lock and hopefully toggle swap, is:

- [ ] Determine best way for boards to establish which side is the Leader-Host side.
- [ ] Possibly interact with the ((weak)) function within svalboard.c to see if it is do-able down that route.
- [ ] Otherwise brainstorm cleaner method for fixing this mismatch in expected behavior without negatively affecting the more 'normie' trackball users... :)

Happy to discuss more.